### PR TITLE
Tracking diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > The immediate goal is to integrate a few missing features from other integrations.
 
 ## Fork Progress
-- [ ] Daily note tagging
+- [x] Daily note tagging
 - [ ] Readwise Reader linking
 - [ ] Option to open in Reader app directly
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Readwise Sync
+# Readwise Sync (fork)
+
+> [!NOTE]
+> This is a WIP fork of the official RemNote Readwise plugin.
+> 
+> The immediate goal is to integrate a few missing features from other integrations.
+
+## Fork Progress
+- [ ] Daily note tagging
+- [ ] Readwise Reader linking
+- [ ] Option to open in Reader app directly
 
 ## Features
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,5 +26,6 @@
       "type": "KnowledgeBaseInfo",
       "level": "Read"
     }
-  ]
+  ],
+  "unlisted": true
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,7 @@
   "version": {
     "major": 0,
     "minor": 0,
-    "patch": 27
+    "patch": 1
   },
   "minimumRemNoteVersion": {
     "major": 1,

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,11 +1,11 @@
 {
-  "author": "Jamesb",
-  "name": "Readwise Sync",
+  "author": "samvtran",
+  "name": "Readwise Sync - Fork",
   "description": "Sync your Readwise highlights with RemNote",
   "enableOnMobile": true,
-  "id": "Jamesb-qb7y5il",
+  "id": "samvtran-readwise-sync",
   "manifestVersion": 1,
-  "repoUrl": "https://github.com/bjsi/remnote-readwise",
+  "repoUrl": "https://github.com/samvtran/remnote-readwise",
   "version": {
     "major": 0,
     "minor": 0,

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -17,6 +17,7 @@ export const bookSlots = {
 
 export const highlightSlots = {
   highlightId: 'readwise-highlight-id',
+  highlightedAt: 'readwise-highlighted-at',
   tags: 'readwise-tags',
   note: 'readwise-note-1',
 };

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -150,8 +150,7 @@ const findOrCreateHighlight = async (
   bookRem: Rem,
   allHighlightsById: Record<string, Rem>
 ): Promise<Either<string, Rem>> => {
-  let highlightRem: Rem | undefined = allHighlightsById[highlight.id.toString()];
-  highlightRem = highlightRem ? highlightRem : await plugin.rem.createRem();
+  const highlightRem = allHighlightsById[highlight.id.toString()] ?? await plugin.rem.createRem();
   if (!highlightRem) {
     return {
       success: false,
@@ -165,41 +164,47 @@ const findOrCreateHighlight = async (
       error: 'Could not find highlights parent for book: ' + bookRem.text?.[0],
     };
   }
-  highlightRem.setParent(parent!._id);
+  await highlightRem.setParent(parent!._id);
   if (
     highlight.text &&
     // don't overwrite if user edited
-    (await plugin.richText.empty(highlightRem.text || []))
+    (await plugin.richText.empty(highlightRem.text || []).catch(e => {
+      console.info('Error parsing existing highlight rem. Assume edited.', highlightRem.text, e);
+      return false;
+    }))
   ) {
-    highlightRem.setText(await convertToRichTextArray(plugin, highlight.text));
+    await highlightRem.setText(await convertToRichTextArray(plugin, highlight.text));
   }
   await highlightRem.addPowerup(powerups.highlight);
   if (highlight.id) {
-    highlightRem.setPowerupProperty(powerups.highlight, highlightSlots.highlightId, [
+    await highlightRem.setPowerupProperty(powerups.highlight, highlightSlots.highlightId, [
       highlight.id.toString(),
     ]);
   } else {
     return { success: false, error: `Highlight for book ${bookRem.text?.[0]} has no id` };
   }
   if (highlight.note) {
-    highlightRem.setPowerupProperty(powerups.highlight, highlightSlots.note, [highlight.note]);
+    await highlightRem.setPowerupProperty(powerups.highlight, highlightSlots.note, [highlight.note]);
   }
 
   if (highlight.tags && highlight.tags.length > 0) {
-    // highlightRem.setPowerupProperty(powerups.highlight, highlightSlots.tags, [
-    //   highlight.tags.map((x) => x.name).join(', '),
-    // ]);
-
     for (const tag of highlight.tags) {
       const tagRem = await findOrCreateTopLevelRem(plugin, tag.name);
       if (tagRem) {
-        highlightRem.addTag(tagRem);
+        await highlightRem.addTag(tagRem);
       }
     }
   }
   if (highlight.readwise_url) {
-    addLinkAsSource(plugin, highlightRem, highlight.readwise_url);
+    await addLinkAsSource(plugin, highlightRem, highlight.readwise_url);
   }
+
+  const dailyNote = await plugin.date.getDailyDoc(new Date(highlight.highlighted_at));
+  if (dailyNote) {
+    const richText = await plugin.richText.rem(dailyNote).value();
+    await highlightRem.setPowerupProperty(powerups.highlight, highlightSlots.highlightedAt, richText);
+  }
+
   return { success: true, data: highlightRem };
 };
 

--- a/src/lib/powerup.ts
+++ b/src/lib/powerup.ts
@@ -54,6 +54,10 @@ async function registerHighlightPowerup(plugin: RNPlugin) {
           code: highlightSlots.note,
           name: 'Note',
         },
+        {
+          code: highlightSlots.highlightedAt,
+          name: 'Highlighted On',
+        }
       ],
     },
   });

--- a/src/lib/types/readwise.ts
+++ b/src/lib/types/readwise.ts
@@ -5,9 +5,9 @@ export interface Highlight {
   location_type: string;
   note?: string;
   color: string;
-  highlighted_at: Date;
-  created_at: Date;
-  updated_at: Date;
+  highlighted_at: string;
+  created_at: string;
+  updated_at: string;
   external_id: string;
   end_location?: any;
   url?: string;


### PR DESCRIPTION
Tracking the diff between upstream and my changes.

# TODO
- [x] Daily note references
- [ ] Image support
- [ ] Refresh single item metadata (retaining edits)
- [ ] Force update single item (overwriting any edits)
- [ ] Add tags based on matches in a configured set (match or upsert, may require some configuration for associating slightly different names?)
- [ ] Template support
- [ ] Readwise Reader linking (may not be doable without a way to get to the Reader document ids)